### PR TITLE
autofocus and enter key bug

### DIFF
--- a/src/components/input-list.js
+++ b/src/components/input-list.js
@@ -24,7 +24,7 @@ function InputList(props) {
             data-testid={`${id}-${i}`}
             value={item}
             onKeyPress={e => {
-              if (e.key === "Enter") {
+              if (e.key === "Enter" && e.target.value !== "") {
                 // Adds another input when the user hits the Enter key
                 items.push("");
                 setItems([...items]);
@@ -47,6 +47,7 @@ function InputList(props) {
               }
               setItems([...items]);
             }}
+            preventEdit={false}
           />
         );
       })}

--- a/src/components/input.js
+++ b/src/components/input.js
@@ -13,10 +13,7 @@ const Wrapper = styled.div`
   position: relative;
 `;
 
-const InputField = styled.input.attrs(props => {
-  // autofocus allows the latest added input field to be in focus except for the special "add another" input field
-  return { autoFocus: !props.preventEdit };
-})`
+const InputField = styled.input`
   /* sets it to either block or inline-block */
   display: ${props => props.display};
   /* removes default highlight and border */
@@ -80,6 +77,8 @@ function Input(props) {
         onKeyPress={props.onKeyPress}
         // onBlur is triggered when you click outside of the input field
         onBlur={props.onBlur}
+        // autofocus allows the latest added input field to be in focus except for the special "add another" input field
+        autoFocus={props.preventEdit === false}
       />
       <DeleteIcon
         data-testid={`${props["data-testid"]}-delete`}


### PR DESCRIPTION
# Context
_What and why?_
1. It focuses at the last added input automatically when the page first loads.
2. Hitting enter on an input in an input-list blurs the input

# Acceptance Criteria
_What needs to be accomplished before we consider it to be complete?_
- [x] Focus should not apply when the page first loads
- [x] Hitting enter on an empty input in an input-list should do nothing

# Testing
_What tests are performed and does it verify the acceptance criteria?_
- [x] Tested behaviors

# Changes Summary
_What are the main changes?_
- Changed input.js and input-list.js

# Links
_What are some helpful links to enrich the context?_
N/A