### PR TITLE
fix autofocus bug

### DIFF
--- a/src/components/input-list.js
+++ b/src/components/input-list.js
@@ -47,7 +47,7 @@ function InputList(props) {
               }
               setItems([...items]);
             }}
-            preventEdit={false}
+            autoFocus={true}
           />
         );
       })}

--- a/src/components/input-list.test.js
+++ b/src/components/input-list.test.js
@@ -1,12 +1,15 @@
 import { render, screen, fireEvent } from "@testing-library/react";
 import InputList from "components/input-list";
 
-test("add item", () => {
+test("add item by typing in the add another input field", () => {
   render(<InputList id="examples" data-testid="examples" />);
   const ele = screen.getByTestId("examples");
   expect(ele).toBeInTheDocument();
 
-  fireEvent.change(screen.getByTestId("examples-add"), {
+  const addEx = screen.getByTestId("examples-add");
+  expect(addEx).not.toHaveFocus();
+
+  fireEvent.change(addEx, {
     target: { value: "this is some example" }
   });
   const ex0 = screen.getByTestId("examples-0");
@@ -14,13 +17,45 @@ test("add item", () => {
   expect(ex0).toHaveFocus();
   expect(ex0).toHaveValue("this is some example");
 
-  fireEvent.change(screen.getByTestId("examples-add"), {
+  fireEvent.change(addEx, {
     target: { value: "this is some other example" }
   });
   const ex1 = screen.getByTestId("examples-1");
   expect(ex1).toBeInTheDocument();
   expect(ex1).toHaveFocus();
   expect(ex1).toHaveValue("this is some other example");
+});
+
+test("add item by hitting enter", () => {
+  render(
+    <InputList
+      id="examples"
+      data-testid="examples"
+      items={["example 0", "example 1"]}
+    />
+  );
+
+  fireEvent.keyPress(screen.getByTestId("examples-1"), {
+    key: "Enter",
+    code: 13,
+    charCode: 13
+  });
+  const ex2 = screen.getByTestId("examples-2");
+  expect(ex2).toBeInTheDocument();
+});
+
+test("item not added by hitting enter on an empty input field", () => {
+  render(
+    <InputList id="examples" data-testid="examples" items={["example 0", ""]} />
+  );
+
+  fireEvent.keyPress(screen.getByTestId("examples-1"), {
+    key: "Enter",
+    code: 13,
+    charCode: 13
+  });
+  const noNewEx = screen.queryByTestId("examples-2");
+  expect(noNewEx).toBeNull();
 });
 
 test("remove item by empty string", () => {

--- a/src/components/input.js
+++ b/src/components/input.js
@@ -13,7 +13,10 @@ const Wrapper = styled.div`
   position: relative;
 `;
 
-const InputField = styled.input`
+const InputField = styled.input.attrs(props => {
+  // autofocus allows the latest added input field to be in focus except for the special "add another" input field
+  return props.autoFocus !== undefined ? { autoFocus: true } : {};
+})`
   /* sets it to either block or inline-block */
   display: ${props => props.display};
   /* removes default highlight and border */
@@ -77,8 +80,7 @@ function Input(props) {
         onKeyPress={props.onKeyPress}
         // onBlur is triggered when you click outside of the input field
         onBlur={props.onBlur}
-        // autofocus allows the latest added input field to be in focus except for the special "add another" input field
-        autoFocus={props.preventEdit === false}
+        autoFocus={props.autoFocus}
       />
       <DeleteIcon
         data-testid={`${props["data-testid"]}-delete`}


### PR DESCRIPTION
# Context
_What and why?_
Autofocus causes a page to jump down when rendered.

# Acceptance Criteria
_What needs to be accomplished before we consider it to be complete?_
- [x] Doesn't autofocus on instantiation
- [x] Input list continue to work as expected

# Testing
_What tests are performed and does it verify the acceptance criteria?_
- [x] Unit test for adding an item by hitting enter
- [x] Unit test for no autofocus on page rendered

# Changes Summary
_What are the main changes?_
- Added the autoFocus variable to differentiate between editable input
- Added unit tests
- ...

# Links
_What are some helpful links to enrich the context?_
N/A