### PR TITLE
automate test ids, add form submission

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "node-sass": "^6.0.1",
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
+        "react-hook-form": "^7.11.1",
         "react-router-dom": "^5.2.0",
         "react-scripts": "4.0.3",
         "styled-components": "^5.3.0",
@@ -17165,6 +17166,18 @@
       "version": "6.0.9",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
       "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew=="
+    },
+    "node_modules/react-hook-form": {
+      "version": "7.11.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.11.1.tgz",
+      "integrity": "sha512-lBt428oU03dNUF5qZy5xqEdANaH3L/ilKWQS2t8wD6zF7FypOv46kEkZmg+oHf3n2xgeGYJgbMIGtYExsfKJ8A==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17"
+      }
     },
     "node_modules/react-is": {
       "version": "17.0.2",
@@ -35927,6 +35940,12 @@
       "version": "6.0.9",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.9.tgz",
       "integrity": "sha512-nQTTcUu+ATDbrSD1BZHr5kgSD4oF8OFjxun8uAaL8RwPBacGBNPf/yAuVVdx17N8XNzRDMrZ9XcKZHCjPW+9ew=="
+    },
+    "react-hook-form": {
+      "version": "7.11.1",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.11.1.tgz",
+      "integrity": "sha512-lBt428oU03dNUF5qZy5xqEdANaH3L/ilKWQS2t8wD6zF7FypOv46kEkZmg+oHf3n2xgeGYJgbMIGtYExsfKJ8A==",
+      "requires": {}
     },
     "react-is": {
       "version": "17.0.2",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "node-sass": "^6.0.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
+    "react-hook-form": "^7.11.1",
     "react-router-dom": "^5.2.0",
     "react-scripts": "4.0.3",
     "styled-components": "^5.3.0",

--- a/src/components/button.js
+++ b/src/components/button.js
@@ -1,0 +1,64 @@
+import styled from 'styled-components'
+import common from 'styles/common.module.scss'
+import colors from 'styles/colors.module.scss'
+import boxshadow from 'styles/boxshadow.module.scss'
+import React, { useRef } from 'react'
+
+// Wrapper is an image with the appropriate padding
+const Wrapper = styled.div`
+  padding: ${props => props.padding};
+  background-color: ${props => {
+    return (
+      {
+        cancel: colors.paper,
+        action: colors.mage
+      }[props.type] || colors.mage
+    )
+  }};
+  color: ${props => {
+    return (
+      {
+        cancel: colors.ink,
+        action: colors.paper
+      }[props.type] || colors.paper
+    )
+  }};
+  cursor: pointer;
+  text-align: center;
+  padding: 0.1em 1em;
+  display: inline-block;
+  border-radius: ${common.borderradius};
+  box-shadow: ${boxshadow.down};
+
+  :hover {
+    opacity: 0.9;
+  }
+`
+
+const SubmitButton = styled.button`
+  display: none;
+`
+
+// Button is a div with a style
+function Button (props) {
+  const submitButton = useRef(null)
+  return (
+    <Wrapper
+      id={props.id}
+      data-testid={props.id}
+      type={props.type}
+      onClick={e => {
+        submitButton.current.click()
+        if (props.onClick) props.onClick(e)
+      }}
+    >
+      {props.children}
+      {props.type === 'submit' ? (
+        <SubmitButton ref={submitButton} type='submit' />
+      ) : (
+        ''
+      )}
+    </Wrapper>
+  )
+}
+export default Button

--- a/src/components/button.test.js
+++ b/src/components/button.test.js
@@ -1,0 +1,18 @@
+import common from "styles/common.module.scss";
+import colors from "styles/colors.module.scss";
+import { render, screen } from "@testing-library/react";
+import Button from "components/button";
+
+test("renders submit button", () => {
+    render(<Button id="button" type="submit" />)
+    const button = screen.getByTestId("button");
+    expect.toHaveStyle(`color: ${colors.paper}`);
+    expect.toHaveStyle(`background-color: ${colors.mage}`);
+});
+
+test("renders cancel button", () => {
+    render(<Button id="button" type="cancel" />)
+    const button = screen.getByTestId("button");
+    expect.toHaveStyle(`background-color: ${colors.paper}`);
+    expect.toHaveStyle(`color: ${colors.ink}`);
+});

--- a/src/components/icon.js
+++ b/src/components/icon.js
@@ -1,5 +1,5 @@
-import styled from "styled-components";
-import common from "styles/common.module.scss";
+import styled from 'styled-components'
+import common from 'styles/common.module.scss'
 
 // Icon is an image with the appropriate padding
 const Icon = styled.img.attrs(props => {
@@ -7,21 +7,21 @@ const Icon = styled.img.attrs(props => {
     lg: common.lg,
     md: common.md,
     sm: common.sm
-  }[props.size];
+  }[props.size]
   const padding = {
     lg: common.lgpad,
     md: common.mdpad,
     sm: common.smpad
-  }[props.size];
+  }[props.size]
   return {
     width: `${size}px`,
     height: `${size}px`,
     padding: `${padding}px`,
-    role: "icon",
-    "data-testid": props["data-testid"]
-  };
+    id: props.id,
+    'data-testid': props.id
+  }
 })`
   padding: ${props => props.padding};
-`;
+`
 
-export default Icon;
+export default Icon

--- a/src/components/icon.test.js
+++ b/src/components/icon.test.js
@@ -3,7 +3,7 @@ import { render, screen } from "@testing-library/react";
 import Icon from "components/icon";
 
 test("renders large icon", () => {
-  render(<Icon data-testid="icon" size="lg" />);
+  render(<Icon id="icon" size="lg" />);
   const icon = screen.getByTestId("icon");
   expect(icon).toBeInTheDocument();
   expect.toHaveStyle(`width: ${common.lg}px`);
@@ -12,7 +12,7 @@ test("renders large icon", () => {
 });
 
 test("renders default icon", () => {
-  render(<Icon data-testid="icon" />);
+  render(<Icon id="icon" />);
   const icon = screen.getByTestId("icon");
   expect(icon).toBeInTheDocument();
   expect.toHaveStyle(`width: ${common.md}px`);
@@ -21,7 +21,7 @@ test("renders default icon", () => {
 });
 
 test("renders small icon", () => {
-  render(<Icon data-testid="icon" size="sm" />);
+  render(<Icon id="icon" size="sm" />);
   const icon = screen.getByTestId("icon");
   expect(icon).toBeInTheDocument();
   expect.toHaveStyle(`width: ${common.sm}px`);

--- a/src/components/input-list.js
+++ b/src/components/input-list.js
@@ -13,15 +13,15 @@ function InputList(props) {
   // items: a list of strings that represents the text in the input fields
   // setItems: updates old items with the given new items
   const [items, setItems] = useState(props.items || []);
-  const id = props["data-testid"];
 
   return (
-    <Wrapper role="list" data-testid={id}>
+    <Wrapper id={props.id} data-testid={props.id}>
       {items.map((item, i) => {
         return (
           <Input
+            id={`${props.id}-${i}`}
+            data-testid={`${props.id}-${i}`}
             key={i}
-            data-testid={`${id}-${i}`}
             value={item}
             onKeyPress={e => {
               if (e.key === "Enter" && e.target.value !== "") {
@@ -52,7 +52,7 @@ function InputList(props) {
         );
       })}
       <Input
-        data-testid={`${id}-add`}
+        id={`${props.id}-add`}
         placeholder="add another..."
         // preventEdit is a flag to tell the Input component it should not be editted}
         preventEdit={true}

--- a/src/components/input-list.test.js
+++ b/src/components/input-list.test.js
@@ -1,102 +1,84 @@
-import { render, screen, fireEvent } from "@testing-library/react";
-import InputList from "components/input-list";
+import { render, screen, fireEvent } from '@testing-library/react'
+import InputList from 'components/input-list'
 
-test("add item by typing in the add another input field", () => {
-  render(<InputList id="examples" data-testid="examples" />);
-  const ele = screen.getByTestId("examples");
-  expect(ele).toBeInTheDocument();
+test('add item by typing in the add another input field', () => {
+  render(<InputList id='examples' />)
+  const ele = screen.getByTestId('examples')
+  expect(ele).toBeInTheDocument()
 
-  const addEx = screen.getByTestId("examples-add");
-  expect(addEx).not.toHaveFocus();
-
-  fireEvent.change(addEx, {
-    target: { value: "this is some example" }
-  });
-  const ex0 = screen.getByTestId("examples-0");
-  expect(ex0).toBeInTheDocument();
-  expect(ex0).toHaveFocus();
-  expect(ex0).toHaveValue("this is some example");
+  const addEx = screen.getByTestId('examples-add')
+  expect(addEx).not.toHaveFocus()
 
   fireEvent.change(addEx, {
-    target: { value: "this is some other example" }
-  });
-  const ex1 = screen.getByTestId("examples-1");
-  expect(ex1).toBeInTheDocument();
-  expect(ex1).toHaveFocus();
-  expect(ex1).toHaveValue("this is some other example");
-});
+    target: { value: 'this is some example' }
+  })
+  const ex0 = screen.getByTestId('examples-0')
+  expect(ex0).toBeInTheDocument()
+  expect(ex0).toHaveFocus()
+  expect(ex0).toHaveValue('this is some example')
 
-test("add item by hitting enter", () => {
-  render(
-    <InputList
-      id="examples"
-      data-testid="examples"
-      items={["example 0", "example 1"]}
-    />
-  );
+  fireEvent.change(addEx, {
+    target: { value: 'this is some other example' }
+  })
+  const ex1 = screen.getByTestId('examples-1')
+  expect(ex1).toBeInTheDocument()
+  expect(ex1).toHaveFocus()
+  expect(ex1).toHaveValue('this is some other example')
+})
 
-  fireEvent.keyPress(screen.getByTestId("examples-1"), {
-    key: "Enter",
+test('add item by hitting enter', () => {
+  render(<InputList id='examples' items={['example 0', 'example 1']} />)
+
+  fireEvent.keyPress(screen.getByTestId('examples-1'), {
+    key: 'Enter',
     code: 13,
     charCode: 13
-  });
-  const ex2 = screen.getByTestId("examples-2");
-  expect(ex2).toBeInTheDocument();
-});
+  })
+  const ex2 = screen.getByTestId('examples-2')
+  expect(ex2).toBeInTheDocument()
+})
 
-test("item not added by hitting enter on an empty input field", () => {
-  render(
-    <InputList id="examples" data-testid="examples" items={["example 0", ""]} />
-  );
+test('item not added by hitting enter on an empty input field', () => {
+  render(<InputList id='examples' items={['example 0', '']} />)
 
-  fireEvent.keyPress(screen.getByTestId("examples-1"), {
-    key: "Enter",
+  fireEvent.keyPress(screen.getByTestId('examples-1'), {
+    key: 'Enter',
     code: 13,
     charCode: 13
-  });
-  const noNewEx = screen.queryByTestId("examples-2");
-  expect(noNewEx).toBeNull();
-});
+  })
+  const noNewEx = screen.queryByTestId('examples-2')
+  expect(noNewEx).toBeNull()
+})
 
-test("remove item by empty string", () => {
+test('remove item by empty string', () => {
+  render(<InputList id='examples' items={['example 0', 'example 1']} />)
+
+  const ex0 = screen.getByTestId('examples-0')
+  expect(ex0).toBeInTheDocument()
+  const ex1 = screen.getByTestId('examples-1')
+  expect(ex1).toBeInTheDocument()
+
+  fireEvent.blur(screen.getByTestId('examples-0'), {
+    target: { value: '' }
+  })
+
+  const removedEx = screen.queryByTestId('examples-1')
+  expect(removedEx).toBeNull()
+})
+
+test('remove item by clicking delete', () => {
   render(
-    <InputList
-      id="examples"
-      data-testid="examples"
-      items={["example 0", "example 1"]}
-    />
-  );
+    <InputList id='examples' items={['example 0', 'example 1', 'example 2']} />
+  )
 
-  const ex0 = screen.getByTestId("examples-0");
-  expect(ex0).toBeInTheDocument();
-  const ex1 = screen.getByTestId("examples-1");
-  expect(ex1).toBeInTheDocument();
+  const ex0 = screen.getByTestId('examples-0')
+  expect(ex0).toBeInTheDocument()
+  const ex1 = screen.getByTestId('examples-1')
+  expect(ex1).toBeInTheDocument()
+  const ex2 = screen.getByTestId('examples-2')
+  expect(ex2).toBeInTheDocument()
 
-  fireEvent.blur(screen.getByTestId("examples-0"), {
-    target: { value: "" }
-  });
-
-  const removedEx = screen.queryByTestId("examples-1");
-  expect(removedEx).toBeNull();
-});
-
-test("remove item by clicking delete", () => {
-  render(
-    <InputList
-      id="examples"
-      data-testid="examples"
-      items={["example 0", "example 1", "example 2"]}
-    />
-  );
-
-  const ex0 = screen.getByTestId("examples-0");
-  expect(ex0).toBeInTheDocument();
-  const ex1 = screen.getByTestId("examples-1");
-  expect(ex1).toBeInTheDocument();
-  const ex2 = screen.getByTestId("examples-2");
-  expect(ex2).toBeInTheDocument();
-
-  fireEvent.click(screen.getByTestId("examples-1-delete"), {});
-  const removedEx = screen.queryByTestId("examples-2");
-  expect(removedEx).toBeNull();
-});
+  fireEvent.click(screen.getByTestId('examples-1-delete'), {})
+  const removedEx = screen.queryByTestId('examples-2')
+  expect(removedEx).toBeNull()
+})

--- a/src/components/input.js
+++ b/src/components/input.js
@@ -1,21 +1,21 @@
-import styled from "styled-components";
-import common from "styles/common.module.scss";
-import colors from "styles/colors.module.scss";
-import boxshadow from "styles/boxshadow.module.scss";
-import closeURL from "assets/icons/close.svg";
-import Icon from "components/icon";
-import React, { useState, useEffect } from "react";
+import styled from 'styled-components'
+import common from 'styles/common.module.scss'
+import colors from 'styles/colors.module.scss'
+import boxshadow from 'styles/boxshadow.module.scss'
+import closeURL from 'assets/icons/close.svg'
+import Icon from 'components/icon'
+import React, { useState, useEffect } from 'react'
 
 const Wrapper = styled.div`
   /* Stretches the input field to container if not inline */
-  width: ${props => (props.inline ? "fit-content" : `calc(100% - 0.5em)`)};
+  width: ${props => (props.inline ? 'fit-content' : `calc(100% - 0.5em)`)};
   /* this helps the delete icon's top, left, bottom, right CSS style adjust relative to the Wrapper element */
   position: relative;
-`;
+`
 
 const InputField = styled.input.attrs(props => {
   // autofocus allows the latest added input field to be in focus except for the special "add another" input field
-  return props.autoFocus !== undefined ? { autoFocus: true } : {};
+  return props.autoFocus !== undefined ? { autoFocus: true } : {}
 })`
   /* sets it to either block or inline-block */
   display: ${props => props.display};
@@ -33,7 +33,7 @@ const InputField = styled.input.attrs(props => {
   width: calc(100% - 1em);
   /* inputs will show  */
   text-overflow: ellipsis;
-`;
+`
 
 const DeleteIcon = styled(Icon)`
   /* positions the delete icon relative to the Wrapper parent element  */
@@ -43,38 +43,40 @@ const DeleteIcon = styled(Icon)`
   top: ${common.sm / 2}px;
   /* hides it when there is no text */
   visibility: ${props => props.visibility};
-`;
+`
 
 // Input is an input field with a style and extra features
-function Input(props) {
+function Input (props) {
   // value: the text entered into the input field
-  const [value, setValue] = useState(props.value || "");
+  const [value, setValue] = useState(props.value || '')
 
   // useEffect() is invoked after the component finished rendering
   // value is updated here when InputList changes its item values
   // this only happens after the input is finished renderiing
   useEffect(() => {
-    if (props.value) setValue(props.value);
-  }, [props.value]);
+    if (props.value) setValue(props.value)
+  }, [props.value])
 
   return (
-    <Wrapper inline={props.inline} role="input">
+    <Wrapper inline={props.inline}>
       <InputField
-        data-testid={props["data-testid"]}
+        id={props.id}
+        data-testid={props.id}
+        name={props.id}
         // value is the text entered in the input field
         value={value}
         // placeholder is the greyed out text in the input field
         placeholder={props.placeholder}
         // stylinig it a little bit
-        display={props.inline ? "inline-block" : "block"}
-        className="md"
-        filled={value !== ""}
+        display={props.inline ? 'inline-block' : 'block'}
+        className='md'
+        filled={value !== ''}
         // onChange is triggered when the text value of the input field is changed
         onChange={e => {
           // updates the input field
-          if (!props.preventEdit) setValue(e.target.value);
+          if (!props.preventEdit) setValue(e.target.value)
           // uses the custom onChange event handler if provided
-          if (props.onChange) props.onChange(e);
+          if (props.onChange) props.onChange(e)
         }}
         // onKeyPress is triggered when you hit a key while the input field is selected
         onKeyPress={props.onKeyPress}
@@ -83,20 +85,20 @@ function Input(props) {
         autoFocus={props.autoFocus}
       />
       <DeleteIcon
-        data-testid={`${props["data-testid"]}-delete`}
+        id={`${props.id}-delete`}
         // show the delete icon only when there is text in the input field
-        visibility={value !== "" ? "visible" : "hidden"}
+        visibility={value !== '' ? 'visible' : 'hidden'}
         // styling it a little bit
-        className="sm clickable"
+        className='sm clickable'
         // src is the URL for the delete (close) icon
         src={closeURL}
         // onClick is tiggered when you click on the delete icon
         // it use the custom onDelete event handler if provided
         // by default otherwise, it clears the input field.
-        onClick={props.onDelete || (() => setValue(""))}
+        onClick={props.onDelete || (() => setValue(''))}
       />
     </Wrapper>
-  );
+  )
 }
 
-export default Input;
+export default Input

--- a/src/components/input.test.js
+++ b/src/components/input.test.js
@@ -2,7 +2,7 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import Input from "components/input";
 
 test("renders inline input", () => {
-  render(<Input data-testid="input" value="" inline />);
+  render(<Input id="input" value="" inline />);
 
   const input = screen.getByTestId("input");
   expect(input).toBeInTheDocument();
@@ -10,7 +10,7 @@ test("renders inline input", () => {
 });
 
 test("renders full width input", () => {
-  render(<Input data-testid="input" value="" />);
+  render(<Input id="input" value="" />);
 
   const input = screen.getByTestId("input");
   expect(input).toBeInTheDocument();
@@ -18,7 +18,7 @@ test("renders full width input", () => {
 });
 
 test("change input to show and hide delete icon", () => {
-  render(<Input data-testid="input" value="" />);
+  render(<Input id="input" value="" />);
 
   const deleteIcon = screen.getByTestId("input-delete");
   expect(deleteIcon).toBeInTheDocument();

--- a/src/components/navbar.js
+++ b/src/components/navbar.js
@@ -77,7 +77,7 @@ const Star = styled.div`
 // Navbar is a navbar that can open and close
 function Navbar(props) {
   return (
-    <Wrapper data-testid={props["data-testid"]} role="navbar">
+    <Wrapper id={props.id} data-testid={props.id}>
       <Top />
       <Bottom>
         <Star />

--- a/src/components/navbar.test.js
+++ b/src/components/navbar.test.js
@@ -9,7 +9,7 @@ const resizeWindow = (width, height) => {
 };
 
 test("render navbar landscape", () => {
-  render(<Navbar data-testid="navbar" />);
+  render(<Navbar id="navbar" />);
 
   const navbar = screen.getByTestId("navbar");
   expect(navbar).toBeInTheDocument();
@@ -17,7 +17,7 @@ test("render navbar landscape", () => {
 });
 
 test("render navbar portrait", () => {
-  render(<Navbar data-testid="navbar" />);
+  render(<Navbar id="navbar" />);
   resizeWindow(250, 600);
 
   const navbar = screen.getByTestId("navbar");

--- a/src/components/page.js
+++ b/src/components/page.js
@@ -35,8 +35,8 @@ const Content = styled.div`
 // Page takes up the entire screen and contains a navbar and content box
 function Page(props) {
   return (
-    <Wrapper role="page" data-testid={props["data-testid"]}>
-      <Navbar data-testid={`${props["data-testid"]}-navbar`} />
+    <Wrapper id={props.id} data-testid={props.id}>
+      <Navbar id={`${props.id}-navbar`} />
       <Content>{props.children}</Content>
     </Wrapper>
   );

--- a/src/components/page.test.js
+++ b/src/components/page.test.js
@@ -3,7 +3,7 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import Page from "components/page";
 
 test("renders page", () => {
-  render(<Page data-testid="page">something</Page>);
+  render(<Page id="page">something</Page>);
 
   const page = screen.getByTestId("page");
   expect(page).toBeInTheDocument();

--- a/src/hooks/form.js
+++ b/src/hooks/form.js
@@ -1,0 +1,46 @@
+const handleSubmit = (handler, validator = {}) => {
+  return e => {
+    e.preventDefault()
+    const data = {}
+    const errs = {}
+    for (let i = 0; i < e.target.length; i++) {
+      const name = e.target.elements[i].getAttribute('name')
+      if (name == null) continue
+      const value = e.target.elements[i].value
+      const keys = name.split(/-(?=[0-9]+$)/)
+
+      if (validator[keys[0]] === undefined) continue
+
+      let target = validate(validator[keys[0]].validate, name, value)
+        ? data
+        : errs
+
+      if (keys.length === 2) {
+        if (!target[keys[0]]) {
+          target[keys[0]] = [value]
+        } else {
+          target[keys[0]].push(value)
+        }
+      } else {
+        target[keys[0]] = value
+      }
+    }
+    handler(data, errs)
+  }
+}
+
+const passwordRegex = new RegExp(
+  '^(?=.*[A-Z].*[A-Z])(?=.*[!@#$&*])(?=.*[0-9].*[0-9])(?=.*[a-z].*[a-z].*[a-z]).{8}$'
+)
+
+const validate = (preset, name, value) => {
+  switch (preset) {
+    case 'password':
+      return passwordRegex.test(value)
+    case 'text':
+    default:
+      return true
+  }
+}
+
+export { handleSubmit }

--- a/src/pages/project-proposal.js
+++ b/src/pages/project-proposal.js
@@ -1,11 +1,13 @@
-import styled from "styled-components";
-import colors from "styles/colors.module.scss";
-import common from "styles/common.module.scss";
-import Page from "components/page";
-import Input from "components/input";
-import InputList from "components/input-list";
+import styled from 'styled-components'
+import colors from 'styles/colors.module.scss'
+import common from 'styles/common.module.scss'
+import Page from 'components/page'
+import Input from 'components/input'
+import Button from 'components/button'
+import InputList from 'components/input-list'
+import { handleSubmit } from 'hooks/form'
 
-const Form = styled.div`
+const Form = styled.form`
   /* adjusts the size of the form */
   width: calc(100% - 6em);
   max-width: 800px;
@@ -18,7 +20,7 @@ const Form = styled.div`
   color: ${colors.ink};
 
   > div {
-    margin: 0.5em 0;
+    margin: 1em 0;
   }
 
   /* when the screen is small, make it take up the whole content box */
@@ -28,39 +30,55 @@ const Form = styled.div`
     margin: 0;
     overflow-y: auto;
   }
-`;
+`
 
-function ProjectProposalPage() {
+const ButtonsWrapper = styled.div`
+  width: 100%;
+  display: flex;
+  justify-content: space-between;
+`
+
+function ProjectProposalPage (props) {
+  const onSubmit = (data, errs) => {
+    console.log(data)
+    if (errs.length > 0) {
+      console.error(errs)
+    }
+  }
+
   return (
-    <Page data-testid="project-proposal">
-      <Form>
-        <div className="lg center">Create Project Proposal</div>
-        <div className="sm bold">Project Name</div>
-        <Input
-          id="project-name"
-          data-testid="project-name"
-          inline
-          placeholder="name your project"
-        />
-        <div className="sm bold">Tagline</div>
-        <div className="sm italic indent">
+    <Page id={props.id}>
+      <Form
+        onSubmit={handleSubmit(onSubmit, {
+          'project-name': { validate: 'text' },
+          tagline: { validate: 'text' },
+          problems: { validate: 'text' },
+          solutions: { validate: 'text' }
+        })}
+      >
+        <div className='lg center'>Create Project Proposal</div>
+        <div className='sm bold'>Project Name</div>
+        <Input id='project-name' inline placeholder='name your project' />
+        <div className='sm bold'>Tagline</div>
+        <div className='sm italic indent'>
           This is the one liner that will get people to check out your project.
         </div>
-        <Input
-          id="tagline"
-          data-testid="tagline"
-          placeholder="enter your tagline"
-        />
-        <div className="sm bold">Problem Statements</div>
-        <div className="sm italic indent">
+        <Input id='tagline' placeholder='enter your tagline' />
+        <div className='sm bold'>Problem Statements</div>
+        <div className='sm italic indent'>
           Breakdown your problems into bullet points. People can echo these
           problems by clicking on the Me Too button. This will help define the
           scope of your project.
         </div>
-        <InputList id="problems" data-testid="problems" />
+        <InputList id='problems' />
+
+        <ButtonsWrapper>
+          <Button type='cancel'>Cancel</Button>
+          <Button type='submit'>Propose</Button>
+        </ButtonsWrapper>
       </Form>
     </Page>
-  );
+  )
 }
 
-export default ProjectProposalPage;
+export default ProjectProposalPage

--- a/src/pages/project-proposal.test.js
+++ b/src/pages/project-proposal.test.js
@@ -1,47 +1,47 @@
-import { render, screen, fireEvent } from "@testing-library/react";
-import ProjectProposalPage from "pages/project-proposal";
+import { render, screen, fireEvent } from '@testing-library/react'
+import ProjectProposalPage from 'pages/project-proposal'
 
-test("renders title and navbar", () => {
-  render(<ProjectProposalPage />);
-  const title = screen.getByText(/create project proposal/i);
-  expect(title).toBeInTheDocument();
-  const navbar = screen.getByRole("navbar");
-  expect(navbar).toBeInTheDocument();
-});
+test('renders title and navbar', () => {
+  render(<ProjectProposalPage id='project-proposal-page' />)
+  const title = screen.getByText(/create project proposal/i)
+  expect(title).toBeInTheDocument()
+  const navbar = screen.getByTestId('project-proposal-page-navbar')
+  expect(navbar).toBeInTheDocument()
+})
 
-test("renders project name", () => {
-  render(<ProjectProposalPage />);
-  const label = screen.getByText(/project name/i);
-  expect(label).toBeInTheDocument();
-  const ele = screen.getByTestId("project-name");
-  expect(ele).toBeInTheDocument();
-});
+test('renders project name', () => {
+  render(<ProjectProposalPage id='project-proposal-page' />)
+  const label = screen.getByText(/project name/i)
+  expect(label).toBeInTheDocument()
+  const ele = screen.getByTestId('project-name')
+  expect(ele).toBeInTheDocument()
+})
 
-test("renders tagline", () => {
-  render(<ProjectProposalPage />);
-  const label = screen.getByText(/tagline/i);
-  expect(label).toBeInTheDocument();
-  const ele = screen.getByTestId("tagline");
-  expect(ele).toBeInTheDocument();
-});
+test('renders tagline', () => {
+  render(<ProjectProposalPage id='project-proposal-page' />)
+  const label = screen.getByText(/tagline/i)
+  expect(label).toBeInTheDocument()
+  const ele = screen.getByTestId('tagline')
+  expect(ele).toBeInTheDocument()
+})
 
-test("renders problem statements", () => {
-  render(<ProjectProposalPage />);
-  const label = screen.getByText(/problem statements/i);
-  expect(label).toBeInTheDocument();
-  const ele = screen.getByTestId("problems");
-  expect(ele).toBeInTheDocument();
+test('renders problem statements', () => {
+  render(<ProjectProposalPage id='project-proposal-page' />)
+  const label = screen.getByText(/problem statements/i)
+  expect(label).toBeInTheDocument()
+  const ele = screen.getByTestId('problems')
+  expect(ele).toBeInTheDocument()
 
-  fireEvent.change(screen.getByTestId("problems-add"), {
-    target: { value: "this is some problem" }
-  });
-  const problem1 = screen.getByTestId("problems-0");
-  expect(problem1).toBeInTheDocument();
-});
+  fireEvent.change(screen.getByTestId('problems-add'), {
+    target: { value: 'this is some problem' }
+  })
+  const problem1 = screen.getByTestId('problems-0')
+  expect(problem1).toBeInTheDocument()
+})
 
 // Add these tests back in once you are ready
 // test("renders solutions", () => {
-//   render(<ProjectProposalPage />);
+//   render(<ProjectProposalPage id="project-proposal-page" />);
 //   const label = screen.getByText(/solutions/i);
 //   expect(label).toBeInTheDocument();
 //   const ele = screen.getByTestId("solutions");
@@ -49,7 +49,7 @@ test("renders problem statements", () => {
 // });
 //
 // test("renders tags", () => {
-//   render(<ProjectProposalPage />);
+//   render(<ProjectProposalPage id="project-proposal-page" />);
 //   const label = screen.getByText(/tags/i);
 //   expect(label).toBeInTheDocument();
 //   const ele = screen.getByTestId("tags");
@@ -57,7 +57,7 @@ test("renders problem statements", () => {
 // });
 //
 // test("renders cover image url", () => {
-//   render(<ProjectProposalPage />);
+//   render(<ProjectProposalPage id="project-proposal-page" />);
 //   const label = screen.getByText(/cover image url/i);
 //   expect(label).toBeInTheDocument();
 //   const ele = screen.getByTestId("cover-image-url");
@@ -65,9 +65,12 @@ test("renders problem statements", () => {
 // });
 //
 // test("renders youtube video url", () => {
-//   render(<ProjectProposalPage />);
+//   render(<ProjectProposalPage id="project-proposal-page" />);
 //   const label = screen.getByText(/youtube video url/i);
 //   expect(label).toBeInTheDocument();
 //   const ele = screen.getByTestId("youtube-video-url");
 //   expect(ele).toBeInTheDocument();
 // });
+//
+// test("collects form data when button is clicked", () => {
+// })


### PR DESCRIPTION
# Context
_What and why?_
Test ids are too clunky and we should just inherit it from real ids.

To propose a project, we need to send this data to the server in a digestable format. React hook `useForm` is not flexible enough as it must use refs and also does not support arrays.

# Acceptance Criteria
_What needs to be accomplished before we consider it to be complete?_
- [x] Inherit test ids from normal ids
- [x] Convert the data to json on form submission

# Testing
_What tests are performed and does it verify the acceptance criteria?_
- [x] Added unit test for buttons

# Changes Summary
_What are the main changes?_
- Added a button component
- Added form collection and validation
- Changed components to inherit test ids from real ids instead

# Links
_What are some helpful links to enrich the context?_
N/A
